### PR TITLE
Updated method of importing chance module

### DIFF
--- a/specs/friendSpec.js
+++ b/specs/friendSpec.js
@@ -2,7 +2,7 @@
  * Example tests of an Angular site
  */
 var friendPage = require('../pages/friendPage');
-var chance = require('../node_modules/chance').Chance();
+var chance = require('chance').Chance();
 
 describe ('angular app', function() {
 


### PR DESCRIPTION
var chance = require('../node_modules/chance').Chance()
does not work since the node_modules/chance does not have an index.js file.